### PR TITLE
Improve feed parsing and posting forms

### DIFF
--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -133,4 +133,28 @@ describe('NoteContent', () => {
     expect(linkText).not.toMatch(/^@npub1/); // Should not be a truncated npub
     expect(linkText).toEqual("@Swift Falcon");
   });
+
+  it('strips internal markers and labels', () => {
+    const event: NostrEvent = {
+      id: 'id',
+      pubkey: 'pk',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags: [],
+      content: '[help] Title: Need water\nDate: Today\nDescription: Bring bottles #CommunityNet',
+      sig: 'sig',
+    };
+
+    render(
+      <TestApp>
+        <NoteContent event={event} />
+      </TestApp>
+    );
+
+    expect(screen.queryByText('[help]')).not.toBeInTheDocument();
+    expect(screen.queryByText('#CommunityNet')).not.toBeInTheDocument();
+    expect(screen.getByText('Need water')).toBeInTheDocument();
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('Bring bottles')).toBeInTheDocument();
+  });
 });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -76,6 +76,7 @@ export default function Index() {
               <PostFormDialog
                 prefix="[help]"
                 title="Request Help"
+                withDetails
                 trigger={
                   <button className="px-4 py-2 rounded-md bg-blue-600 text-white">
                     Request Help
@@ -185,6 +186,7 @@ export default function Index() {
               <PostFormDialog
                 prefix="[knowledge]"
                 title="Share Knowledge"
+                withDetails
                 trigger={
                   <button className="px-4 py-2 rounded-md bg-blue-600 text-white">
                     Share Knowledge
@@ -251,6 +253,7 @@ export default function Index() {
             <PostFormDialog
               prefix="[help]"
               title="Request Help"
+              withDetails
               trigger={
                 <button className="px-4 py-2 rounded-md font-semibold bg-blue-600 text-white hover:bg-blue-700 transition">
                   Request Help
@@ -269,6 +272,7 @@ export default function Index() {
             <PostFormDialog
               prefix="[knowledge]"
               title="Share Knowledge"
+              withDetails
               trigger={
                 <button className="px-4 py-2 rounded-md font-semibold bg-white/80 text-gray-800 border border-gray-300 hover:bg-white transition">
                   Share Knowledge


### PR DESCRIPTION
## Summary
- add optional detail inputs for PostFormDialog
- hide CommunityNet markers and section tags when displaying notes
- support Title/Date/Description fields when rendering notes
- update Index page to use detailed dialogs for help and knowledge
- test stripping of internal markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485ae5caa48326adfac3c5102bdc1a