### PR TITLE
Improve feed responsiveness and detail forms

### DIFF
--- a/index.css
+++ b/index.css
@@ -99,3 +99,18 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .glass-card {
+    @apply bg-white/20 dark:bg-gray-900/40 backdrop-blur-lg border border-white/30 dark:border-gray-700/50 shadow-xl;
+  }
+
+  .glass-button {
+    @apply bg-white/30 dark:bg-gray-800/50 backdrop-blur-md border border-white/30 dark:border-gray-700/50 hover:bg-white/40 dark:hover:bg-gray-800/60 transition;
+  }
+
+  .animate-gradient {
+    background-size: 200% 200%;
+    animation: gradient-pan 15s ease infinite;
+  }
+}

--- a/src/components/FeedDialog.tsx
+++ b/src/components/FeedDialog.tsx
@@ -18,7 +18,7 @@ export function FeedDialog({ trigger, events, title, onZap }: FeedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-w-xl">
+      <DialogContent className="glass-card max-w-xl">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/src/components/MainFeed.tsx
+++ b/src/components/MainFeed.tsx
@@ -33,7 +33,7 @@ export function MainFeed() {
     await publish({
       kind: 1,
       content: finalContent,
-      tags: [['t', 'communitynet']],
+      tags: [["t", "CommunityNet"]],
     });
     setContent("");
     queryClient.invalidateQueries({ queryKey: ["communitynet-feed"] });

--- a/src/components/MainFeed.tsx
+++ b/src/components/MainFeed.tsx
@@ -71,7 +71,7 @@ export function MainFeed() {
         <div>Loading...</div>
       ) : (
         events.map((ev) => (
-          <Card key={ev.id}>
+          <Card key={ev.id} className="glass-card">
             <CardContent>
               <NoteContent event={ev} />
             </CardContent>

--- a/src/components/MainFeed.tsx
+++ b/src/components/MainFeed.tsx
@@ -30,7 +30,11 @@ export function MainFeed() {
     const finalContent = text.endsWith("#CommunityNet")
       ? text
       : `${text} #CommunityNet`;
-    await publish({ kind: 1, content: finalContent });
+    await publish({
+      kind: 1,
+      content: finalContent,
+      tags: [['t', 'communitynet']],
+    });
     setContent("");
     queryClient.invalidateQueries({ queryKey: ["communitynet-feed"] });
   };

--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -205,4 +205,28 @@ describe('NoteContent', () => {
     expect(screen.getByText('Sat')).toBeInTheDocument();
     expect(screen.getByText('Park cleanup')).toBeInTheDocument();
   });
+
+  it('handles posts with label only', () => {
+    const event: NostrEvent = {
+      id: 'id4',
+      pubkey: 'pk',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags: [],
+      content: '[help] Title: Need food\nDate: Now\nDescription: Please bring snacks',
+      sig: 'sig',
+    };
+
+    render(
+      <TestApp>
+        <NoteContent event={event} />
+      </TestApp>
+    );
+
+    expect(screen.queryByText('[help]')).not.toBeInTheDocument();
+    expect(screen.queryByText('#CommunityNet')).not.toBeInTheDocument();
+    expect(screen.getByText('Need food')).toBeInTheDocument();
+    expect(screen.getByText('Now')).toBeInTheDocument();
+    expect(screen.getByText('Please bring snacks')).toBeInTheDocument();
+  });
 });

--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -133,4 +133,76 @@ describe('NoteContent', () => {
     expect(linkText).not.toMatch(/^@npub1/); // Should not be a truncated npub
     expect(linkText).toEqual("@Swift Falcon");
   });
+
+  it('strips internal markers and labels', () => {
+    const event: NostrEvent = {
+      id: 'id',
+      pubkey: 'pk',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags: [],
+      content: '[help] Title: Need water\nDate: Today\nDescription: Bring bottles #CommunityNet',
+      sig: 'sig',
+    };
+
+    render(
+      <TestApp>
+        <NoteContent event={event} />
+      </TestApp>
+    );
+
+    expect(screen.queryByText('[help]')).not.toBeInTheDocument();
+    expect(screen.queryByText('#CommunityNet')).not.toBeInTheDocument();
+    expect(screen.getByText('Need water')).toBeInTheDocument();
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(screen.getByText('Bring bottles')).toBeInTheDocument();
+  });
+
+  it('handles resource posts with details', () => {
+    const event: NostrEvent = {
+      id: 'id2',
+      pubkey: 'pk',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags: [],
+      content: '[resource] Title: Water Bottles\nDate: Tomorrow\nDescription: 20 packs #CommunityNet',
+      sig: 'sig',
+    };
+
+    render(
+      <TestApp>
+        <NoteContent event={event} />
+      </TestApp>
+    );
+
+    expect(screen.queryByText('[resource]')).not.toBeInTheDocument();
+    expect(screen.queryByText('#CommunityNet')).not.toBeInTheDocument();
+    expect(screen.getByText('Water Bottles')).toBeInTheDocument();
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument();
+    expect(screen.getByText('20 packs')).toBeInTheDocument();
+  });
+
+  it('handles action posts with details', () => {
+    const event: NostrEvent = {
+      id: 'id3',
+      pubkey: 'pk',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags: [],
+      content: '[action] Title: Cleanup\nDate: Sat\nDescription: Park cleanup #CommunityNet',
+      sig: 'sig',
+    };
+
+    render(
+      <TestApp>
+        <NoteContent event={event} />
+      </TestApp>
+    );
+
+    expect(screen.queryByText('[action]')).not.toBeInTheDocument();
+    expect(screen.queryByText('#CommunityNet')).not.toBeInTheDocument();
+    expect(screen.getByText('Cleanup')).toBeInTheDocument();
+    expect(screen.getByText('Sat')).toBeInTheDocument();
+    expect(screen.getByText('Park cleanup')).toBeInTheDocument();
+  });
 });

--- a/src/components/PostFormDialog.tsx
+++ b/src/components/PostFormDialog.tsx
@@ -1,17 +1,28 @@
-import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Textarea } from '@/components/ui/textarea';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
-import { Calendar } from '@/components/ui/calendar';
-import { Calendar as CalendarIcon } from 'lucide-react';
-import { format } from 'date-fns';
-import { cn } from '@/lib/utils';
-import { useNostrPublish } from '@/hooks/useNostrPublish';
-import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { useToast } from '@/hooks/useToast';
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useToast } from "@/hooks/useToast";
 
 interface PostFormDialogProps {
   trigger: React.ReactNode;
@@ -31,16 +42,16 @@ export function PostFormDialog({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
-  const [titleInput, setTitleInput] = useState('');
+  const [titleInput, setTitleInput] = useState("");
   const [dateInput, setDateInput] = useState<Date | undefined>();
-  const [description, setDescription] = useState('');
+  const [description, setDescription] = useState("");
 
   const handlePublish = async () => {
     if (!user) {
       toast({
-        title: 'Login required',
-        description: 'Please log in first.',
-        variant: 'destructive',
+        title: "Login required",
+        description: "Please log in first.",
+        variant: "destructive",
       });
       return;
     }
@@ -50,24 +61,24 @@ export function PostFormDialog({
     } else {
       if (!text) return;
     }
-    const formattedDate = dateInput ? format(dateInput, 'yyyy-MM-dd') : '';
+    const formattedDate = dateInput ? format(dateInput, "yyyy-MM-dd") : "";
     const body = withDetails
       ? `Title: ${titleInput}\nDate: ${formattedDate}\nDescription: ${text}`
       : text;
 
     const category = prefix.match(/\[(.*)\]/)?.[1]?.toLowerCase();
-    const tags = [['t', 'communitynet']];
-    if (category) tags.push(['t', category]);
+    const tags = [["t", "CommunityNet"]];
+    if (category) tags.push(["t", category]);
 
     await publish({
       kind: 1,
       content: `${prefix} ${body} #CommunityNet`,
       tags,
     });
-    queryClient.invalidateQueries({ queryKey: ['communitynet-feed'] });
-    setTitleInput('');
+    queryClient.invalidateQueries({ queryKey: ["communitynet-feed"] });
+    setTitleInput("");
     setDateInput(undefined);
-    setDescription('');
+    setDescription("");
     setOpen(false);
   };
 
@@ -91,12 +102,16 @@ export function PostFormDialog({
                 <Button
                   variant="outline"
                   className={cn(
-                    'w-full justify-start text-left font-normal',
-                    !dateInput && 'text-muted-foreground',
+                    "w-full justify-start text-left font-normal",
+                    !dateInput && "text-muted-foreground"
                   )}
                 >
                   <CalendarIcon className="mr-2 h-4 w-4" />
-                  {dateInput ? format(dateInput, 'PPP') : <span>Pick a date</span>}
+                  {dateInput ? (
+                    format(dateInput, "PPP")
+                  ) : (
+                    <span>Pick a date</span>
+                  )}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="p-0 w-auto" align="start">

--- a/src/components/PostFormDialog.tsx
+++ b/src/components/PostFormDialog.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
@@ -10,14 +12,23 @@ interface PostFormDialogProps {
   trigger: React.ReactNode;
   prefix: string;
   title: string;
+  withDetails?: boolean;
 }
 
-export function PostFormDialog({ trigger, prefix, title }: PostFormDialogProps) {
+export function PostFormDialog({
+  trigger,
+  prefix,
+  title,
+  withDetails,
+}: PostFormDialogProps) {
   const { mutateAsync: publish } = useNostrPublish();
   const { user } = useCurrentUser();
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
-  const [content, setContent] = useState('');
+  const [titleInput, setTitleInput] = useState('');
+  const [dateInput, setDateInput] = useState('');
+  const [description, setDescription] = useState('');
 
   const handlePublish = async () => {
     if (!user) {
@@ -28,10 +39,20 @@ export function PostFormDialog({ trigger, prefix, title }: PostFormDialogProps) 
       });
       return;
     }
-    const text = content.trim();
-    if (!text) return;
-    await publish({ kind: 1, content: `${prefix} ${text} #CommunityNet` });
-    setContent('');
+    const text = description.trim();
+    if (withDetails) {
+      if (!titleInput.trim() && !text) return;
+    } else {
+      if (!text) return;
+    }
+    const body = withDetails
+      ? `Title: ${titleInput}\nDate: ${dateInput}\nDescription: ${text}`
+      : text;
+    await publish({ kind: 1, content: `${prefix} ${body} #CommunityNet` });
+    queryClient.invalidateQueries({ queryKey: ['communitynet-feed'] });
+    setTitleInput('');
+    setDateInput('');
+    setDescription('');
     setOpen(false);
   };
 
@@ -42,10 +63,26 @@ export function PostFormDialog({ trigger, prefix, title }: PostFormDialogProps) 
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
+        {withDetails && (
+          <div className="space-y-2 mb-4">
+            <Input
+              value={titleInput}
+              onChange={(e) => setTitleInput(e.target.value)}
+              placeholder="Title"
+              className=""
+            />
+            <Input
+              value={dateInput}
+              onChange={(e) => setDateInput(e.target.value)}
+              placeholder="Date"
+              className=""
+            />
+          </div>
+        )}
         <Textarea
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="Write your note..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={withDetails ? "Description" : "Write your note..."}
           className="mb-4"
         />
         <DialogFooter>

--- a/src/components/PostFormDialog.tsx
+++ b/src/components/PostFormDialog.tsx
@@ -49,7 +49,7 @@ export function PostFormDialog({
     if (withDetails) {
       if (!titleInput.trim() && !text) return;
     } else {
-      if (!text) return;
+      <DialogContent className="glass-card">
     }
     const body = withDetails
       ? `Title: ${titleInput}\nDate: ${dateInput}\nDescription: ${text}`

--- a/src/components/PostFormDialog.tsx
+++ b/src/components/PostFormDialog.tsx
@@ -66,7 +66,7 @@ export function PostFormDialog({
     });
     queryClient.invalidateQueries({ queryKey: ['communitynet-feed'] });
     setTitleInput('');
-    setDateInput('');
+    setDateInput(undefined);
     setDescription('');
     setOpen(false);
   };

--- a/src/hooks/useCommunityNetFeed.ts
+++ b/src/hooks/useCommunityNetFeed.ts
@@ -2,6 +2,12 @@ import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
 import type { NostrEvent } from '@nostrify/nostrify';
 
+/**
+ * Fetch community notes from Nostr and keep them refreshed.
+ *
+ * Events are identified if the content contains #CommunityNet or any of the
+ * category labels like [knowledge], [help], [resource], or [action].
+ */
 export function useCommunityNetFeed() {
   const { nostr } = useNostr();
 
@@ -13,7 +19,13 @@ export function useCommunityNetFeed() {
         { signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]) },
       );
       return events
-        .filter((e) => e.content.includes('#CommunityNet'))
+        .filter((e) => {
+          const c = e.content.toLowerCase();
+          return (
+            c.includes('#communitynet') ||
+            /\[(knowledge|help|resource|action)\]/i.test(c)
+          );
+        })
         .sort((a, b) => b.created_at - a.created_at);
     },
     refetchInterval: 30000,

--- a/src/hooks/useCommunityNetFeed.ts
+++ b/src/hooks/useCommunityNetFeed.ts
@@ -5,9 +5,9 @@ import type { NostrEvent } from '@nostrify/nostrify';
 /**
  * Fetch community notes from Nostr and keep them refreshed.
  *
- * Events are tagged with `t` tags so we can query by category at the relay
- * level. We include tags for `communitynet` and the category label such as
- * `help`, `resource`, `action`, or `knowledge`.
+ * Events are tagged with `t` tags. We fetch notes that include the
+ * `communitynet` tag and then filter them by category tags such as `help`,
+ * `resource`, `action`, or `knowledge` on the client.
 */
 export function useCommunityNetFeed() {
   const { nostr } = useNostr();
@@ -19,7 +19,7 @@ export function useCommunityNetFeed() {
         [
           {
             kinds: [1],
-            '#t': ['communitynet', 'help', 'resource', 'action', 'knowledge'],
+            '#t': ['communitynet'],
             limit: 100,
           },
         ],

--- a/src/hooks/useCommunityNetFeed.ts
+++ b/src/hooks/useCommunityNetFeed.ts
@@ -1,6 +1,6 @@
-import { useNostr } from '@nostrify/react';
-import { useQuery } from '@tanstack/react-query';
-import type { NostrEvent } from '@nostrify/nostrify';
+import { useNostr } from "@nostrify/react";
+import { useQuery } from "@tanstack/react-query";
+import type { NostrEvent } from "@nostrify/nostrify";
 
 /**
  * Fetch community notes from Nostr and keep them refreshed.
@@ -8,26 +8,26 @@ import type { NostrEvent } from '@nostrify/nostrify';
  * Events are tagged with `t` tags. We fetch notes that include the
  * `communitynet` tag and then filter them by category tags such as `help`,
  * `resource`, `action`, or `knowledge` on the client.
-*/
+ */
 export function useCommunityNetFeed() {
   const { nostr } = useNostr();
 
   return useQuery<NostrEvent[]>({
-    queryKey: ['communitynet-feed'],
+    queryKey: ["communitynet-feed"],
     queryFn: async ({ signal }) => {
       const events = await nostr.query(
         [
           {
             kinds: [1],
-            '#t': ['communitynet'],
+            "#t": ["CommunityNet"],
             limit: 100,
           },
         ],
-        { signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]) },
+        { signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]) }
       );
 
       return events.sort((a, b) => b.created_at - a.created_at);
     },
-    refetchInterval: 30000,
+    refetchInterval: 1000,
   });
 }

--- a/src/hooks/useCommunityNetFeed.ts
+++ b/src/hooks/useCommunityNetFeed.ts
@@ -5,9 +5,10 @@ import type { NostrEvent } from '@nostrify/nostrify';
 /**
  * Fetch community notes from Nostr and keep them refreshed.
  *
- * Events are identified if the content contains #CommunityNet or any of the
- * category labels like [knowledge], [help], [resource], or [action].
- */
+ * Events are tagged with `t` tags so we can query by category at the relay
+ * level. We include tags for `communitynet` and the category label such as
+ * `help`, `resource`, `action`, or `knowledge`.
+*/
 export function useCommunityNetFeed() {
   const { nostr } = useNostr();
 
@@ -15,18 +16,17 @@ export function useCommunityNetFeed() {
     queryKey: ['communitynet-feed'],
     queryFn: async ({ signal }) => {
       const events = await nostr.query(
-        [{ kinds: [1], limit: 100 }],
+        [
+          {
+            kinds: [1],
+            '#t': ['communitynet', 'help', 'resource', 'action', 'knowledge'],
+            limit: 100,
+          },
+        ],
         { signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]) },
       );
-      return events
-        .filter((e) => {
-          const c = e.content.toLowerCase();
-          return (
-            c.includes('#communitynet') ||
-            /\[(knowledge|help|resource|action)\]/i.test(c)
-          );
-        })
-        .sort((a, b) => b.created_at - a.created_at);
+
+      return events.sort((a, b) => b.created_at - a.created_at);
     },
     refetchInterval: 30000,
   });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function hasTag(event: { tags: string[][] }, tag: string) {
+  return event.tags.some(
+    ([t, v]) => t === 't' && (v ?? '').toLowerCase() === tag.toLowerCase(),
+  );
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import { FeedDialog } from "@/components/FeedDialog";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { NoteContent } from "@/components/NoteContent";
 import { useCommunityNetFeed } from "@/hooks/useCommunityNetFeed";
+import { hasTag } from "@/lib/utils";
 
 export default function Index() {
   useSeoMeta({
@@ -17,10 +18,18 @@ export default function Index() {
 
   const { data: events = [] } = useCommunityNetFeed();
 
-  const resources = events.filter((e) => e.content.includes("[resource]"));
-  const help = events.filter((e) => e.content.includes("[help]"));
-  const actions = events.filter((e) => e.content.includes("[action]"));
-  const knowledge = events.filter((e) => e.content.includes("[knowledge]"));
+  const resources = events.filter(
+    (e) => hasTag(e, "resource") || e.content.includes("[resource]")
+  );
+  const help = events.filter(
+    (e) => hasTag(e, "help") || e.content.includes("[help]")
+  );
+  const actions = events.filter(
+    (e) => hasTag(e, "action") || e.content.includes("[action]")
+  );
+  const knowledge = events.filter(
+    (e) => hasTag(e, "knowledge") || e.content.includes("[knowledge]")
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-600 to-purple-700 text-gray-900 dark:text-gray-100">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,10 +32,10 @@ export default function Index() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-600 to-purple-700 text-gray-900 dark:text-gray-100">
+    <div className="min-h-screen bg-gradient-to-br from-fuchsia-500 via-purple-600 to-indigo-500 text-gray-900 dark:text-gray-100 bg-[length:200%_200%] animate-gradient">
       <div className="container mx-auto px-6 py-8">
         {/* — Header — */}
-        <div className="bg-white/90 dark:bg-gray-900/75 backdrop-blur-md rounded-2xl p-6 mb-8 shadow-lg flex flex-col md:flex-row justify-between items-center gap-4">
+        <div className="glass-card rounded-2xl p-6 mb-8 flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="space-y-2">
             <h1 className="text-3xl font-bold">CommunityNet</h1>
             <p className="text-lg text-gray-700 dark:text-gray-300">
@@ -56,7 +56,7 @@ export default function Index() {
                   Show Feed
                 </button>
               </DialogTrigger>
-              <DialogContent className="max-w-xl">
+              <DialogContent className="glass-card max-w-xl">
                 <MainFeed />
               </DialogContent>
             </Dialog>
@@ -67,7 +67,7 @@ export default function Index() {
         {/* — Three-column cards — */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           {/* Urgent Needs */}
-          <div className="bg-white/90 dark:bg-gray-800/75 backdrop-blur-md rounded-2xl p-6 shadow-lg border-l-4 border-red-500 hover:-translate-y-1 transform transition">
+          <div className="glass-card rounded-2xl p-6 border-l-4 border-red-500 hover:-translate-y-1 transform transition">
             <h3 className="text-xl font-semibold mb-4">
               🚨 Urgent Community Needs
             </h3>
@@ -96,7 +96,7 @@ export default function Index() {
                 events={help}
                 title="Help Requests"
                 trigger={
-                  <button className="px-4 py-2 rounded-md bg-white/80 text-gray-800 border border-gray-300">
+                  <button className="px-4 py-2 rounded-md glass-button text-gray-800">
                     Show Feed
                   </button>
                 }
@@ -105,7 +105,7 @@ export default function Index() {
           </div>
 
           {/* Available Resources */}
-          <div className="bg-white/90 dark:bg-gray-800/75 backdrop-blur-md rounded-2xl p-6 shadow-lg border-l-4 border-green-500 hover:-translate-y-1 transform transition">
+          <div className="glass-card rounded-2xl p-6 border-l-4 border-green-500 hover:-translate-y-1 transform transition">
             <h3 className="text-xl font-semibold mb-4">
               🤝 Available Resources
             </h3>
@@ -134,7 +134,7 @@ export default function Index() {
                 events={resources}
                 title="Resources"
                 trigger={
-                  <button className="px-4 py-2 rounded-md bg-white/80 text-gray-800 border border-gray-300">
+                  <button className="px-4 py-2 rounded-md glass-button text-gray-800">
                     Show Feed
                   </button>
                 }
@@ -143,7 +143,7 @@ export default function Index() {
           </div>
 
           {/* Organizing Actions */}
-          <div className="bg-white/90 dark:bg-gray-800/75 backdrop-blur-md rounded-2xl p-6 shadow-lg border-l-4 border-blue-500 hover:-translate-y-1 transform transition">
+          <div className="glass-card rounded-2xl p-6 border-l-4 border-blue-500 hover:-translate-y-1 transform transition">
             <h3 className="text-xl font-semibold mb-4">
               ⚡ Organizing Actions
             </h3>
@@ -172,7 +172,7 @@ export default function Index() {
                 events={actions}
                 title="Actions"
                 trigger={
-                  <button className="px-4 py-2 rounded-md bg-white/80 text-gray-800 border border-gray-300">
+                  <button className="px-4 py-2 rounded-md glass-button text-gray-800">
                     Show Feed
                   </button>
                 }
@@ -181,7 +181,7 @@ export default function Index() {
           </div>
 
           {/* Shared Knowledge */}
-          <div className="bg-white/90 dark:bg-gray-800/75 backdrop-blur-md rounded-2xl p-6 shadow-lg border-l-4 border-purple-500 hover:-translate-y-1 transform transition">
+          <div className="glass-card rounded-2xl p-6 border-l-4 border-purple-500 hover:-translate-y-1 transform transition">
             <h3 className="text-xl font-semibold mb-4">📚 Shared Knowledge</h3>
             <div className="space-y-3">
               {knowledge.map((ev) => (
@@ -208,7 +208,7 @@ export default function Index() {
                 events={knowledge}
                 title="Knowledge"
                 trigger={
-                  <button className="px-4 py-2 rounded-md bg-white/80 text-gray-800 border border-gray-300">
+                  <button className="px-4 py-2 rounded-md glass-button text-gray-800">
                     Show Feed
                   </button>
                 }
@@ -218,7 +218,7 @@ export default function Index() {
         </div>
 
         {/* — Map Section — */}
-        <div className="bg-white/90 dark:bg-gray-800/75 backdrop-blur-md rounded-2xl p-6 shadow-lg mb-8">
+        <div className="glass-card rounded-2xl p-6 mb-8">
           <h3 className="text-xl font-semibold mb-4">Community Activity Map</h3>
           <div className="relative rounded-xl h-64 mb-4 bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-700 dark:to-gray-800 flex items-center justify-center text-gray-500 dark:text-gray-400">
             <div className="text-center space-y-1">
@@ -278,7 +278,7 @@ export default function Index() {
               title="Start Action"
               withDetails
               trigger={
-                <button className="px-4 py-2 rounded-md font-semibold bg-white/80 text-gray-800 border border-gray-300 hover:bg-white transition">
+                <button className="px-4 py-2 rounded-md font-semibold glass-button text-gray-800">
                   Start Organizing Action
                 </button>
               }
@@ -288,7 +288,7 @@ export default function Index() {
               title="Share Knowledge"
               withDetails
               trigger={
-                <button className="px-4 py-2 rounded-md font-semibold bg-white/80 text-gray-800 border border-gray-300 hover:bg-white transition">
+                <button className="px-4 py-2 rounded-md font-semibold glass-button text-gray-800">
                   Share Knowledge
                 </button>
               }
@@ -297,7 +297,7 @@ export default function Index() {
         </div>
 
         {/* — Network Status — */}
-        <div className="bg-white/90 dark:bg-gray-800/75 backdrop-blur-md rounded-2xl p-6 shadow-lg">
+        <div className="glass-card rounded-2xl p-6">
           <h3 className="text-xl font-semibold mb-2">Network Status</h3>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
             Decentralized on NOSTR protocol • No central servers •

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -76,6 +76,7 @@ export default function Index() {
               <PostFormDialog
                 prefix="[help]"
                 title="Request Help"
+                withDetails
                 trigger={
                   <button className="px-4 py-2 rounded-md bg-blue-600 text-white">
                     Request Help
@@ -113,6 +114,7 @@ export default function Index() {
               <PostFormDialog
                 prefix="[resource]"
                 title="Add Resource"
+                withDetails
                 trigger={
                   <button className="px-4 py-2 rounded-md bg-blue-600 text-white">
                     Add Resource
@@ -150,6 +152,7 @@ export default function Index() {
               <PostFormDialog
                 prefix="[action]"
                 title="Start Action"
+                withDetails
                 trigger={
                   <button className="px-4 py-2 rounded-md bg-blue-600 text-white">
                     Start Action
@@ -185,6 +188,7 @@ export default function Index() {
               <PostFormDialog
                 prefix="[knowledge]"
                 title="Share Knowledge"
+                withDetails
                 trigger={
                   <button className="px-4 py-2 rounded-md bg-blue-600 text-white">
                     Share Knowledge
@@ -227,6 +231,7 @@ export default function Index() {
                   key={i}
                   prefix="[action]"
                   title="Start Action"
+                  withDetails
                   trigger={
                     <div
                       className={`absolute w-3 h-3 rounded-full ${pt.color} cursor-pointer`}
@@ -242,6 +247,7 @@ export default function Index() {
             <PostFormDialog
               prefix="[resource]"
               title="Add Resource"
+              withDetails
               trigger={
                 <button className="px-4 py-2 rounded-md font-semibold bg-blue-600 text-white hover:bg-blue-700 transition">
                   Add Resource/Skill
@@ -251,6 +257,7 @@ export default function Index() {
             <PostFormDialog
               prefix="[help]"
               title="Request Help"
+              withDetails
               trigger={
                 <button className="px-4 py-2 rounded-md font-semibold bg-blue-600 text-white hover:bg-blue-700 transition">
                   Request Help
@@ -260,6 +267,7 @@ export default function Index() {
             <PostFormDialog
               prefix="[action]"
               title="Start Action"
+              withDetails
               trigger={
                 <button className="px-4 py-2 rounded-md font-semibold bg-white/80 text-gray-800 border border-gray-300 hover:bg-white transition">
                   Start Organizing Action
@@ -269,6 +277,7 @@ export default function Index() {
             <PostFormDialog
               prefix="[knowledge]"
               title="Share Knowledge"
+              withDetails
               trigger={
                 <button className="px-4 py-2 rounded-md font-semibold bg-white/80 text-gray-800 border border-gray-300 hover:bg-white transition">
                   Share Knowledge

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -85,11 +85,16 @@ export default {
 					to: {
 						height: '0'
 					}
-				}
+				},
+                                'gradient-pan': {
+                                        '0%, 100%': { backgroundPosition: '0% 50%' },
+                                        '50%': { backgroundPosition: '100% 50%' }
+                                }
 			},
 			animation: {
 				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out'
+				'accordion-up': 'accordion-up 0.2s ease-out',
+                                'gradient-pan': 'gradient-pan 15s ease infinite'
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
- refresh main feed immediately after posting
- support title/date/description fields for resources and actions
- test parsing for resource and action notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485ae5caa48326adfac3c5102bdc1a